### PR TITLE
add command line args support and break when out of messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .env
+name.session
+output/

--- a/src/script.py
+++ b/src/script.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 from telethon.sync import TelegramClient, events
 from telethon.tl.functions.messages import GetDialogsRequest
 from telethon.tl.functions.channels import GetFullChannelRequest
@@ -5,19 +6,30 @@ from telethon.tl.types import InputPeerEmpty
 from tqdm import tqdm
 from dotenv import load_dotenv
 import os
+import argparse
 
 load_dotenv()
 # You must get your own api_id and
 # api_hash from https://my.telegram.org, under API Development.
 api_id = os.getenv('API_ID')
 api_hash = os.getenv('API_HASH')
-path_to_save = os.getenv('PATH_TO_SAVE')
+
+parser = argparse.ArgumentParser(description="Telegram file downloader")
+parser.add_argument('-o','--output', help="output folder", default=os.getenv('PATH_TO_SAVE'), metavar='')
+parser.add_argument('-l','--limit', help="number of messages to fetch per request", default=50, type=int, metavar='')
+parser.add_argument('-r','--requests', help="number of requests to attempt (stops when there is no more messages to fetch)", default=3100, type=int, metavar='')
+parser.add_argument('-c','--channel', help="channel to fetch messages from", default="example title", metavar='')
+
+args = parser.parse_args()
+path_to_save = args.output
 
 def download_media(group, cl, name):
-    limit = 50 # limit of files by request. I recommend to set a small number.
+    limit = args.limit # limit of files by request. I recommend to set a small number.
 
-    for x in range(3100): # Range is how many files you want to download divided by limit.
+    for x in range(args.requests): # Range is how many files you want to download divided by limit.
       messages = cl.get_messages(group, limit=limit, add_offset=x*limit)
+      if (len(messages) == 0):
+        break
       for message in tqdm(messages):
         try:
           if message.file:
@@ -51,7 +63,7 @@ with TelegramClient('name', api_id, api_hash) as client:
         hash=0,
     ))
 
-    title = 'example title'         # Title for channel
+    title = args.channel         # Title for channel
     channel = client(GetFullChannelRequest(title))
     print(channel.full_chat)
 


### PR DESCRIPTION
add command line args support. you can view them by running the script with -h or --help flag.

the script now stops making requests whens there are no messages left.